### PR TITLE
Add restcomm-verify.sh to verify docker container environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,14 @@ ADD ./scripts/docker_do.sh   /opt/embed/restcomm_docker.sh
 
 RUN mkdir -p /etc/my_init.d
 
-ADD ./scripts/restcomm_autoconf.sh /etc/my_init.d/restcomm1.sh
-ADD ./scripts/restcomm_conf.sh /etc/my_init.d/restcomm2.sh
-ADD ./scripts/restcomm_sslconf.sh /etc/my_init.d/restcomm3.sh
-ADD ./scripts/restcomm_extconf.sh /etc/my_init.d/restcomm4.sh
-ADD ./scripts/restcomm_toolsconf.sh /etc/my_init.d/restcomm5.sh
-ADD ./scripts/restcomm-runlevels.sh /etc/my_init.d/restcomm6.sh
-ADD ./scripts/restcomm_tag.sh /etc/my_init.d/restcomm7.sh
+ADD ./scripts/restcomm_verify.sh /etc/my_init.d/restcomm1.sh
+ADD ./scripts/restcomm_autoconf.sh /etc/my_init.d/restcomm2.sh
+ADD ./scripts/restcomm_conf.sh /etc/my_init.d/restcomm3.sh
+ADD ./scripts/restcomm_sslconf.sh /etc/my_init.d/restcomm4.sh
+ADD ./scripts/restcomm_extconf.sh /etc/my_init.d/restcomm5.sh
+ADD ./scripts/restcomm_toolsconf.sh /etc/my_init.d/restcomm6.sh
+ADD ./scripts/restcomm-runlevels.sh /etc/my_init.d/restcomm7.sh
+ADD ./scripts/restcomm_tag.sh /etc/my_init.d/restcomm8.sh
 
 ADD ./scripts/restcomm_service.sh /tmp/restcomm_service.sh
 ADD ./scripts/rms_service.sh /tmp/rms_service.sh

--- a/scripts/restcomm_verify.sh
+++ b/scripts/restcomm_verify.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mem=$(awk '/^MemTotal:/{print $2}' /proc/meminfo)
+
+if [ "$mem" -lt "4000000" ]; then
+    echo "ERROR: $mem of RAM is not enough to start Telestax RestComm. Min required value is 4000000"
+    exit 1
+fi
+
+exit 0

--- a/scripts/start-restcomm.sh
+++ b/scripts/start-restcomm.sh
@@ -29,33 +29,33 @@ startRestcomm() {
     case $run_mode in
         'standalone'*)
             # start restcomm on standalone mode
-			chmod +x $RESTCOMM_HOME/bin/standalone.sh
-			if [[ "$RUN_DOCKER" == "true" || "$RUN_DOCKER" == "TRUE" ]]; then
+	    chmod +x $RESTCOMM_HOME/bin/standalone.sh
+	    if [[ "$RUN_DOCKER" == "true" || "$RUN_DOCKER" == "TRUE" ]]; then
                 echo 'Telestax RestComm started running on standalone mode.'
                 echo "Using IP Address: $BIND_ADDRESS"
                 #change to second runlevel.
                 runsvchdir second >/dev/null
                 $RESTCOMM_HOME/bin/standalone.sh -b $bind_address "${ExtraOpts}"
-			else
+	    else
                 tmux new -s restcomm -d "$RESTCOMM_HOME/bin/standalone.sh -b $bind_address ${ExtraOpts}"
                 echo 'Telestax RestComm started running on standalone mode. Terminal session: restcomm.'
                 echo "Using IP Address: $BIND_ADDRESS"
-			fi
-			;;
-		'domain'*)
-			# start restcomm on standalone mode
-			chmod +x $RESTCOMM_HOME/bin/domain.sh
-			tmux new -s restcomm -d "$RESTCOMM_HOME/bin/domain.sh -b $bind_address ${ExtraOpts}"
-			echo 'Telestax RestComm started running on domain mode. Screen session: restcomm.'
-			echo "Using IP Address: $BIND_ADDRESS"
-			;;
-		*)
-			# start restcomm on standalone mode
-			chmod +x $RESTCOMM_HOME/bin/standalone.sh
-			tmux new -s restcomm -d "$RESTCOMM_HOME/bin/standalone.sh -b $bind_address ${ExtraOpts}"
-			echo 'Telestax RestComm started running on standalone mode. Screen session: restcomm.'
-			echo "Using IP Address: $BIND_ADDRESS"
-			;;
+	    fi
+	    ;;
+	'domain'*)
+	    # start restcomm on standalone mode
+	    chmod +x $RESTCOMM_HOME/bin/domain.sh
+	    tmux new -s restcomm -d "$RESTCOMM_HOME/bin/domain.sh -b $bind_address ${ExtraOpts}"
+	    echo 'Telestax RestComm started running on domain mode. Screen session: restcomm.'
+	    echo "Using IP Address: $BIND_ADDRESS"
+	    ;;
+	*)
+	    # start restcomm on standalone mode
+	    chmod +x $RESTCOMM_HOME/bin/standalone.sh
+	    tmux new -s restcomm -d "$RESTCOMM_HOME/bin/standalone.sh -b $bind_address ${ExtraOpts}"
+	    echo 'Telestax RestComm started running on standalone mode. Screen session: restcomm.'
+	    echo "Using IP Address: $BIND_ADDRESS"
+	    ;;
 	esac
 
 }

--- a/scripts/start-restcomm.sh
+++ b/scripts/start-restcomm.sh
@@ -30,14 +30,16 @@ startRestcomm() {
 		'standalone'*)
 			# start restcomm on standalone mode
 			chmod +x $RESTCOMM_HOME/bin/standalone.sh
-			echo ' Telestax RestComm started running on standalone mode. Terminal session: restcomm.'
-			echo "Using IP Address: $BIND_ADDRESS"
 			if [[ "$RUN_DOCKER" == "true" || "$RUN_DOCKER" == "TRUE" ]]; then
+     			echo 'Telestax RestComm started running on standalone mode.'
+	    		echo "Using IP Address: $BIND_ADDRESS"
 			    #change to second runlevel.
 			    runsvchdir second >/dev/null
 				$RESTCOMM_HOME/bin/standalone.sh -b $bind_address "${ExtraOpts}"
 			else
 				tmux new -s restcomm -d "$RESTCOMM_HOME/bin/standalone.sh -b $bind_address ${ExtraOpts}"
+     			echo 'Telestax RestComm started running on standalone mode. Terminal session: restcomm.'
+	    		echo "Using IP Address: $BIND_ADDRESS"
 			fi
 			;;
 		'domain'*)

--- a/scripts/start-restcomm.sh
+++ b/scripts/start-restcomm.sh
@@ -26,18 +26,18 @@ startRestcomm() {
         grep -q "$MGMT_USER" $RESTCOMM_HOME/standalone/configuration/mgmt-users.properties || $RESTCOMM_HOME/bin/add-user.sh "$MGMT_USER" "$MGMT_PASS" -s
     fi
 
-	case $run_mode in
-		'standalone'*)
-			# start restcomm on standalone mode
+    case $run_mode in
+        'standalone'*)
+            # start restcomm on standalone mode
 			chmod +x $RESTCOMM_HOME/bin/standalone.sh
 			if [[ "$RUN_DOCKER" == "true" || "$RUN_DOCKER" == "TRUE" ]]; then
                 echo 'Telestax RestComm started running on standalone mode.'
                 echo "Using IP Address: $BIND_ADDRESS"
-			    #change to second runlevel.
-			    runsvchdir second >/dev/null
-				$RESTCOMM_HOME/bin/standalone.sh -b $bind_address "${ExtraOpts}"
+                #change to second runlevel.
+                runsvchdir second >/dev/null
+                $RESTCOMM_HOME/bin/standalone.sh -b $bind_address "${ExtraOpts}"
 			else
-				tmux new -s restcomm -d "$RESTCOMM_HOME/bin/standalone.sh -b $bind_address ${ExtraOpts}"
+                tmux new -s restcomm -d "$RESTCOMM_HOME/bin/standalone.sh -b $bind_address ${ExtraOpts}"
                 echo 'Telestax RestComm started running on standalone mode. Terminal session: restcomm.'
                 echo "Using IP Address: $BIND_ADDRESS"
 			fi

--- a/scripts/start-restcomm.sh
+++ b/scripts/start-restcomm.sh
@@ -31,15 +31,15 @@ startRestcomm() {
 			# start restcomm on standalone mode
 			chmod +x $RESTCOMM_HOME/bin/standalone.sh
 			if [[ "$RUN_DOCKER" == "true" || "$RUN_DOCKER" == "TRUE" ]]; then
-     			echo 'Telestax RestComm started running on standalone mode.'
-	    		echo "Using IP Address: $BIND_ADDRESS"
+                echo 'Telestax RestComm started running on standalone mode.'
+                echo "Using IP Address: $BIND_ADDRESS"
 			    #change to second runlevel.
 			    runsvchdir second >/dev/null
 				$RESTCOMM_HOME/bin/standalone.sh -b $bind_address "${ExtraOpts}"
 			else
 				tmux new -s restcomm -d "$RESTCOMM_HOME/bin/standalone.sh -b $bind_address ${ExtraOpts}"
-     			echo 'Telestax RestComm started running on standalone mode. Terminal session: restcomm.'
-	    		echo "Using IP Address: $BIND_ADDRESS"
+                echo 'Telestax RestComm started running on standalone mode. Terminal session: restcomm.'
+                echo "Using IP Address: $BIND_ADDRESS"
 			fi
 			;;
 		'domain'*)


### PR DESCRIPTION
I tried to run RC using Docker on my Mac with default 2Gb of RAM.
'stdout' is a kind of mess and it didn't give some useful information about startup problems (one jboss failed with OoM).
It will be better to prevent such situations.